### PR TITLE
support '-token-default-mode' to configure defaultMode of token volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Usage of /gcp-workload-identity-federation-webhook:
         The default audience for tokens. Can be overridden by annotation (default "sts.googleapis.com")
   -token-expiration duration
         The token expiration (default 24h0m0s)
+  -token-default-mode int
+        DefaultMode for the token volume (default 440)
   -zap-devel
         Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
   -zap-encoder value

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Usage of /gcp-workload-identity-federation-webhook:
   -token-expiration duration
         The token expiration (default 24h0m0s)
   -token-default-mode int
-        DefaultMode for the token volume (default 440)
+        DefaultMode for the token volume (default 0440)
   -zap-devel
         Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
   -zap-encoder value

--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -41,7 +41,6 @@ controllerManager:
     # - --setup-container-resources=
     # # DefaultMode for the token volume (default 440)
     # - --token-default-mode=
-        
     resources:
       limits:
         cpu: 500m

--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -39,7 +39,7 @@ controllerManager:
     # - --gcloud-image=google/cloud-sdk:slim
     # # Resource spec in json for the init container setting up GCloud SDK, e.g. '{"requests":{"cpu":"100m"}}'
     # - --setup-container-resources=
-    # # DefaultMode for the token volume (default 440)
+    # # DefaultMode for the token volume (default 0440 (octal int literal))
     # - --token-default-mode=
     resources:
       limits:

--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -39,6 +39,9 @@ controllerManager:
     # - --gcloud-image=google/cloud-sdk:slim
     # # Resource spec in json for the init container setting up GCloud SDK, e.g. '{"requests":{"cpu":"100m"}}'
     # - --setup-container-resources=
+    # # DefaultMode for the token volume (default 440)
+    # - --token-default-mode=
+        
     resources:
       limits:
         cpu: 500m

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	defaultTokenExpiration := flag.Duration("token-expiration", webhooks.DefaultTokenExpirationDefault, "The token expiration")
 	defaultRegion := flag.String("gcp-default-region", "", "If set, CLOUDSDK_COMPUTE_REGION will be set to this value in mutated containers")
 	gCloudImage := flag.String("gcloud-image", webhooks.GcloudImageDefault, "Container image for the init container setting up GCloud SDK")
-	tokenDefaultMode := flag.Int("token-default-mode", webhooks.VolumeModeDefault, "DefaultMode for the token volume")
+	tokenDefaultMode := flag.Int("token-default-mode", webhooks.VolumeModeDefault, "DefaultMode for the token volume. CAUTION: if you allow reading from others (e.g. '0444'), the token can read from anyone who can log in to the node.")
 	setupContainerResources := flag.String("setup-container-resources", webhooks.SetupContainerResources, `Resource spec in json for the init container setting up GCloud SDK, e.g. '{"requests":{"cpu":"100m"}}'`)
 
 	opts := zap.Options{

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 	defaultTokenExpiration := flag.Duration("token-expiration", webhooks.DefaultTokenExpirationDefault, "The token expiration")
 	defaultRegion := flag.String("gcp-default-region", "", "If set, CLOUDSDK_COMPUTE_REGION will be set to this value in mutated containers")
 	gCloudImage := flag.String("gcloud-image", webhooks.GcloudImageDefault, "Container image for the init container setting up GCloud SDK")
+	tokenDefaultMode := flag.Int("token-default-mode", webhooks.VolumeModeDefault, "DefaultMode for the token volume")
 	setupContainerResources := flag.String("setup-container-resources", webhooks.SetupContainerResources, `Resource spec in json for the init container setting up GCloud SDK, e.g. '{"requests":{"cpu":"100m"}}'`)
 
 	opts := zap.Options{
@@ -95,6 +96,7 @@ func main() {
 		MinTokenExpration:       webhooks.MinTokenExprationDefault,
 		DefaultGCloudRegion:     *defaultRegion,
 		GcloudImage:             *gCloudImage,
+		DefaultMode:             int32(*tokenDefaultMode),
 		SetupContainerResources: setupContainerResourceRequirements,
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to setup gcp-workload-identity-mutator")

--- a/webhooks/constants.go
+++ b/webhooks/constants.go
@@ -10,6 +10,7 @@ const (
 	MinTokenExprationDefault      = time.Duration(1) * time.Hour
 	DefaultGCloudRegionDefault    = "asia-northeast1"
 	GcloudImageDefault            = "google/cloud-sdk:slim"
+	VolumeModeDefault             = 440
 	SetupContainerResources       = ""
 
 	// Constants for injected fields

--- a/webhooks/constants.go
+++ b/webhooks/constants.go
@@ -10,7 +10,7 @@ const (
 	MinTokenExprationDefault      = time.Duration(1) * time.Hour
 	DefaultGCloudRegionDefault    = "asia-northeast1"
 	GcloudImageDefault            = "google/cloud-sdk:slim"
-	VolumeModeDefault             = 440
+	VolumeModeDefault             = 0440
 	SetupContainerResources       = ""
 
 	// Constants for injected fields

--- a/webhooks/mutatepod.go
+++ b/webhooks/mutatepod.go
@@ -58,7 +58,7 @@ func (m *GCPWorkloadIdentityMutator) mutatePod(pod *corev1.Pod, idConfig GCPWork
 	//
 	// mutate volumes(k8s sa token volume, gcloud config volume)
 	//
-	for _, v := range volumesToAddOrReplace(audience, expirationSeconds) {
+	for _, v := range volumesToAddOrReplace(audience, expirationSeconds, int32(m.DefaultMode)) {
 		pod.Spec.Volumes = addOrReplaceVolume(pod.Spec.Volumes, v)
 	}
 

--- a/webhooks/mutatepod_parts.go
+++ b/webhooks/mutatepod_parts.go
@@ -42,7 +42,7 @@ func k8sSATokenVolume(
 						Path:              K8sSATokenName,
 					},
 				}},
-				DefaultMode: pointer.Int32(0440),
+				DefaultMode: pointer.Int32(444),
 			},
 		},
 	}

--- a/webhooks/mutatepod_parts.go
+++ b/webhooks/mutatepod_parts.go
@@ -23,13 +23,15 @@ var (
 func volumesToAddOrReplace(
 	audience string,
 	expirationSeconds int64,
+	defaultMode int32,
 ) []corev1.Volume {
-	return []corev1.Volume{k8sSATokenVolume(audience, expirationSeconds), gcloudConfigVolume}
+	return []corev1.Volume{k8sSATokenVolume(audience, expirationSeconds, defaultMode), gcloudConfigVolume}
 }
 
 func k8sSATokenVolume(
 	audience string,
 	expirationSeconds int64,
+	defaultMode int32,
 ) corev1.Volume {
 	return corev1.Volume{
 		Name: K8sSATokenVolumeName,
@@ -42,7 +44,7 @@ func k8sSATokenVolume(
 						Path:              K8sSATokenName,
 					},
 				}},
-				DefaultMode: pointer.Int32(444),
+				DefaultMode: pointer.Int32(defaultMode),
 			},
 		},
 	}

--- a/webhooks/mutatepod_test.go
+++ b/webhooks/mutatepod_test.go
@@ -14,6 +14,7 @@ import (
 
 var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 	var m *GCPWorkloadIdentityMutator
+	var defaultMode int32 = 777
 	project := "demo"
 	BeforeEach(func() {
 		m = &GCPWorkloadIdentityMutator{
@@ -23,6 +24,7 @@ var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 			MinTokenExpration:      MinTokenExprationDefault,
 			DefaultGCloudRegion:    DefaultGCloudRegionDefault,
 			GcloudImage:            GcloudImageDefault,
+			DefaultMode:            defaultMode,
 			SetupContainerResources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("100m"),
@@ -154,7 +156,7 @@ var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 						VolumeMounts: volumeMountsToAddOrReplace,
 						Env:          expectedEnvVars,
 					}},
-					Volumes: volumesToAddOrReplace("my-audience", 3601),
+					Volumes: volumesToAddOrReplace("my-audience", 3601, defaultMode),
 				},
 			}
 			// Expect(pod.Annotations).To(BeEquivalentTo(expected.Annotations))
@@ -221,6 +223,7 @@ var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 					Volumes: volumesToAddOrReplace(
 						m.DefaultAudience,
 						(int64)(m.DefaultTokenExpiration.Seconds()),
+						defaultMode,
 					),
 				},
 			}

--- a/webhooks/mutatepod_test.go
+++ b/webhooks/mutatepod_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 	var m *GCPWorkloadIdentityMutator
-	var defaultMode int32 = 777
+	var defaultMode int32 = 0400
 	project := "demo"
 	BeforeEach(func() {
 		m = &GCPWorkloadIdentityMutator{

--- a/webhooks/mutator.go
+++ b/webhooks/mutator.go
@@ -36,6 +36,7 @@ type GCPWorkloadIdentityMutator struct {
 	MinTokenExpration       time.Duration
 	DefaultGCloudRegion     string
 	GcloudImage             string
+	DefaultMode             int32
 	SetupContainerResources *corev1.ResourceRequirements
 
 	logger  logr.Logger

--- a/webhooks/mutator_test.go
+++ b/webhooks/mutator_test.go
@@ -99,7 +99,7 @@ var _ = Describe("GCPWorkloadIdentityMutator", func() {
 						VolumeMounts: volumeMountsToAddOrReplace,
 						Env:          append(envVarsToAddOrReplace, envVarsToAddIfNotPresent(DefaultGCloudRegionDefault, project)...),
 					})},
-					Volumes: volumesToAddOrReplace(audience, tokenExpiration),
+					Volumes: volumesToAddOrReplace(audience, tokenExpiration, VolumeModeDefault),
 				},
 			}
 

--- a/webhooks/webhook_suite_test.go
+++ b/webhooks/webhook_suite_test.go
@@ -83,6 +83,7 @@ var _ = BeforeSuite(func() {
 		MinTokenExpration:       MinTokenExprationDefault,
 		DefaultGCloudRegion:     DefaultGCloudRegionDefault,
 		GcloudImage:             GcloudImageDefault,
+		DefaultMode:             VolumeModeDefault,
 		SetupContainerResources: setupContainerResources,
 	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The access permissions in the volume were still wrong (288), this PR fixes it. This PR also adds read access for others, as the primary userId could not be in neither in the same group, so it can't access to the volume

Fixes https://github.com/pfnet-research/gcp-workload-identity-federation-webhook/issues/15