### PR TITLE
update security context to fit restricted profile in PSS

### DIFF
--- a/webhooks/mutatepod_parts.go
+++ b/webhooks/mutatepod_parts.go
@@ -56,7 +56,15 @@ func gcloudSetupContainer(
 	runAsUser *int64,
 	resources *corev1.ResourceRequirements,
 ) corev1.Container {
-	var securityContext *corev1.SecurityContext
+	// for Restricted Profile in Pod Security Standards
+	securityContext := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				"ALL",
+			},
+		},
+	}
 	if runAsUser != nil {
 		securityContext = &corev1.SecurityContext{
 			RunAsUser: runAsUser,


### PR DESCRIPTION
Update SecurityContext of the injecting gcloud-setup container.
https://kubernetes.io/docs/concepts/security/pod-security-standards/