### PR TITLE
Fix security context for PSS restricted policy being overridden when runAsUser specified

### DIFF
--- a/webhooks/mutatepod_parts.go
+++ b/webhooks/mutatepod_parts.go
@@ -65,10 +65,9 @@ func gcloudSetupContainer(
 			},
 		},
 	}
+
 	if runAsUser != nil {
-		securityContext = &corev1.SecurityContext{
-			RunAsUser: runAsUser,
-		}
+		securityContext.RunAsUser = runAsUser
 	}
 
 	c := corev1.Container{


### PR DESCRIPTION
This PR fixes a bug introduced by #18, in which Security Context for PSS `restricted` policy is overridden when `gcloud-run-as-user` annotation is specified.