### PR TITLE
Fix webhook server port

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -85,11 +84,6 @@ func main() {
 		Metrics: metricsserver.Options{
 			BindAddress: *metricsAddr,
 		},
-		WebhookServer: webhook.NewServer(
-			webhook.Options{
-				Port: 944,
-			},
-		),
 		HealthProbeBindAddress: *probeAddr,
 	})
 	if err != nil {


### PR DESCRIPTION
#28 introduced a bug that the webhook server listens on 944 port, not 9443.
https://github.com/pfnet-research/gcp-workload-identity-federation-webhook/pull/28/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R88-R92

This PR fixes this bug, by removing `WebhookServer` from `ctrl.Options`.
When `WebhookServer == nil`, `ctrl.NewManager` will create a webhook server with the default options, using 9443 port by  default.

- https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/manager/manager.go#L241
- https://github.com/kubernetes-sigs/controller-runtime/blob/56159419231e985c091ef3e7a8a3dee40ddf1d73/pkg/webhook/server.go#L39