### PR TITLE
Switch gcloud image source to Artifact Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Note: GKE or Anthos natively support injecting workload identity for pods.  This
       initContainers:
         ### gcloud-setup init container is injected by the webhook ###
       - name: gcloud-setup
-        image: google/cloud-sdk:slim
+        image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
         command:
         - sh
         - -c
@@ -236,7 +236,7 @@ Usage of /gcp-workload-identity-federation-webhook:
   -annotation-prefix string
         The Service Account annotation to look for (default "cloud.google.com")
   -gcloud-image string
-        Container image for the init container setting up GCloud SDK (default "google/cloud-sdk:slim")
+        Container image for the init container setting up GCloud SDK (default "gcr.io/google.com/cloudsdktool/google-cloud-cli:stable")
   -gcp-default-region string
         If set, CLOUDSDK_COMPUTE_REGION will be set to this value in mutated containers
   -health-probe-bind-address string

--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -36,7 +36,7 @@ controllerManager:
     # # If set, CLOUDSDK_COMPUTE_REGION will be set to this value in mutated containers
     # - --gcp-default-region=
     # # Container image for the init container setting up GCloud SDK
-    # - --gcloud-image=google/cloud-sdk:slim
+    # - --gcloud-image=gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
     # # Resource spec in json for the init container setting up GCloud SDK, e.g. '{"requests":{"cpu":"100m"}}'
     # - --setup-container-resources=
     # # DefaultMode for the token volume (default 0440 (octal int literal))

--- a/webhooks/constants.go
+++ b/webhooks/constants.go
@@ -9,7 +9,7 @@ const (
 	DefaultTokenExpirationDefault = time.Duration(24) * time.Hour
 	MinTokenExprationDefault      = time.Duration(1) * time.Hour
 	DefaultGCloudRegionDefault    = "asia-northeast1"
-	GcloudImageDefault            = "google/cloud-sdk:slim"
+	GcloudImageDefault            = "gcr.io/google.com/cloudsdktool/google-cloud-cli:stable"
 	VolumeModeDefault             = 0440
 	SetupContainerResources       = ""
 

--- a/webhooks/mutatepod_parts_test.go
+++ b/webhooks/mutatepod_parts_test.go
@@ -14,7 +14,7 @@ func TestGcloudSetupContainer(t *testing.T) {
 		workloadIdProvider = "projects/12345/locations/global/workloadIdentityPools/on-prem-kubernetes/providers/this-cluster"
 		saEmail            = "app-x@project.iam.googleapis.com"
 		project            = "project"
-		gcloudImage        = "google/cloud-sdk:slim"
+		gcloudImage        = "gcr.io/google.com/cloudsdktool/google-cloud-cli:stable"
 	)
 
 	expectedTemplate := corev1.Container{


### PR DESCRIPTION
Fixes #97 

Switch the Google Cloud CLI image source from Docker Hub to Google Artifact Registry so that users will not be affected by the rate limit.

`slim` tag images are actually not slim; they have additional software.
So I switched the tag to `stable` too.
https://cloud.google.com/sdk/docs/downloads-docker#installing_a_docker_image:~:text=%3Aslim%2C%20%3AVERSION%2Dslim%3A%20Similar%20to%20stable%20but%20includes%20the%20additional%20third%20party%20packages%20like%20curl%2C%20python3%2Dcrcmod%2C%20apt%2Dtransport%2Dhttps%2C%20lsb%2Drelease%2C%20openssh%2Dclient%2C%20git%2C%20make%2C%20and%20gnupg.