### PR TITLE
feat: add token-exchange-mode for direct resource access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 
 bin/
+.idea

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Note: GKE or Anthos natively support injecting workload identity for pods.  This
         #           The value must be one of 'gcloud'(default) or 'direct'.
         #           Refer to the next section for 'direct' injection mode
         cloud.google.com/injection-mode: "gcloud"
+
+        # optional: Token exchange mode. Value must be one of 'service-account' (default) or 'direct-access'.
+        #           Refer to the "Direct Resource Access" section for 'direct-access' mode.
+        cloud.google.com/token-exchange-mode: "service-account"
+
+        # optional: GCP project ID injected as CLOUDSDK_CORE_PROJECT in mutated pods.
+        #           When unset, the webhook extracts the project ID from
+        #           cloud.google.com/service-account-email. Set this explicitly to override,
+        #           or when no SA email is available (e.g. in 'direct-access' mode).
+        cloud.google.com/project-id: "project"
     ```
 
 4. All new pods launched using the Kubernetes `ServiceAccount` will be mutated so that they can impersonate the GCP service account. Below is an example pod spec with the environment variables and volume fields mutated by the webhook.
@@ -138,7 +148,79 @@ Note: GKE or Anthos natively support injecting workload identity for pods.  This
 
 When running a container with a non-root user, you need to give user id for GCloud SDK container using the annotation `cloud.google.com/gcloud-run-as-user` in the service account.
 
-## Experimental Direct Credential Injection Mode
+## Token Exchange Modes
+
+Select via the ServiceAccount annotation `cloud.google.com/token-exchange-mode`.
+
+### Service Account Impersonation (default)
+
+The value `service-account` (or an absent annotation) preserves existing behavior: the exchanged STS token impersonates the GCP service account in `cloud.google.com/service-account-email`. See the "Walk Through" section above for setup.
+
+### Direct Resource Access
+
+In `direct-access` mode the webhook configures the workload to access GCP resources directly as the federated principal, with no intermediate service account. This removes the service-account management step but requires IAM bindings that reference the federated principal directly.
+
+1. Annotate the Kubernetes ServiceAccount:
+
+    ```yaml
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: app-x
+      namespace: service-a
+      annotations:
+        cloud.google.com/workload-identity-provider: "projects/12345/locations/global/workloadIdentityPools/on-prem-kubernetes/providers/this-cluster"
+        cloud.google.com/token-exchange-mode: "direct-access"
+        # cloud.google.com/service-account-email is not required (it is ignored if present)
+        # optional: project ID injected as CLOUDSDK_CORE_PROJECT for gcloud / Application Default Credentials.
+        # Without this, direct-access mode cannot derive a project ID (the workload-identity-provider only
+        # exposes the project number).
+        cloud.google.com/project-id: "my-project"
+    ```
+
+2. Grant IAM bindings on the resources you want the workload to access. Bind the `principal://` (single subject) or `principalSet://` (attribute set) member, not a service account:
+
+    ```
+    # example: grant Storage Object Viewer on a bucket to a single subject
+    gcloud storage buckets add-iam-policy-binding gs://my-bucket \
+      --member='principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/on-prem-kubernetes/subject/SUBJECT_VALUE' \
+      --role=roles/storage.objectViewer
+    ```
+
+    Replace `SUBJECT_VALUE` with whatever value is produced by the `google.subject` attribute mapping in your Workload Identity Pool Provider.
+
+    For an attribute-based binding, use `principalSet://...workloadIdentityPools/POOL_ID/attribute.NAME/VALUE`.
+
+    See the [Google Cloud documentation on impersonation vs. direct resource access][impersonation-vs-direct] for details and the [list of products that support direct resource access][direct-support].
+
+3. The resulting pod spec is similar to the "Direct" injection example below, except the `cloud.google.com/external-credentials-json` annotation does not contain a `service_account_impersonation_url` field. Example:
+
+    ```json
+    {
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/on-prem-kubernetes/providers/this-cluster",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "file": "/var/run/secrets/sts.googleapis.com/serviceaccount/token",
+        "format": { "type": "text" }
+      }
+    }
+    ```
+
+[impersonation-vs-direct]: https://cloud.google.com/iam/docs/workload-identity-federation#impersonation_versus_direct_resource_access
+[direct-support]: https://cloud.google.com/iam/docs/federated-identity-supported-services
+
+## Credential Injection Modes
+
+The webhook has two independent configuration axes for ServiceAccounts:
+
+- **Token Exchange Mode** (see "Token Exchange Modes" above): what the exchanged STS token represents — a GCP Service Account (default) or the federated principal itself.
+- **Credential Injection Mode** (this section): how the generated external credential configuration is delivered to the pod — via a `gcloud` init container (default) or directly through a DownwardAPI volume.
+
+Defaults (`service-account` + `gcloud`) preserve behavior from earlier releases.
+
+### Direct (Experimental)
 
 In this mode, the Workload Identity Federation Webhook controller directly generates the Gcloud external credentials configuration and injects into the pod.
 This means the `gcloud-setup` init container is not required which can speed up pod start time.

--- a/webhooks/annotations.go
+++ b/webhooks/annotations.go
@@ -43,4 +43,23 @@ const (
 	//
 	// Set to 'direct' or 'gcloud' to determine credential injection mode. Defaults to 'gcloud'.
 	InjectionModeAnnotation = "injection-mode"
+
+	//
+	// Annotations for ServiceAccount
+	//
+	// Set to 'service-account' or 'direct-access' to determine the GCP token exchange mode.
+	// Defaults to 'service-account'. In 'direct-access' mode, the ServiceAccountEmailAnnotation
+	// is ignored and the exchanged STS token is used to access GCP resources directly as the
+	// federated principal (no impersonation).
+	TokenExchangeModeAnnotation = "token-exchange-mode"
+
+	//
+	// Annotations for ServiceAccount
+	//
+	// Optional GCP project ID, used to populate CLOUDSDK_CORE_PROJECT in mutated pods.
+	// When set, overrides the project ID extracted from ServiceAccountEmailAnnotation.
+	// Useful in 'direct-access' token-exchange-mode where no service-account-email is
+	// available, or when the workload should target a project other than the one in the
+	// service account email.
+	ProjectIDAnnotation = "project-id"
 )

--- a/webhooks/external_account_config.go
+++ b/webhooks/external_account_config.go
@@ -31,7 +31,7 @@ type ExternalAccountCredentials struct {
 	TokenInfoURL string `json:"token_info_url,omitempty"`
 	// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
 	// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
-	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url"`
+	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url,omitempty"`
 	// ServiceAccountImpersonationLifetimeSeconds is the number of seconds the service account impersonation
 	// token will be valid for.
 	ServiceAccountImpersonationLifetimeSeconds int `json:"service_account_impersonation_lifetime_seconds,omitempty"`
@@ -53,7 +53,7 @@ type CredentialFormat struct {
 	Type string `json:"type"`
 }
 
-func NewExternalAccountCredentials(aud, gsaEmail string) *ExternalAccountCredentials {
+func NewExternalAccountCredentials(aud string, gsaEmail *string) *ExternalAccountCredentials {
 	creds := &ExternalAccountCredentials{
 		Type:             "external_account",
 		Audience:         aud,
@@ -63,7 +63,13 @@ func NewExternalAccountCredentials(aud, gsaEmail string) *ExternalAccountCredent
 			File:   filepath.Join(K8sSATokenMountPath, K8sSATokenName),
 			Format: CredentialFormat{Type: "text"},
 		},
-		ServiceAccountImpersonationURL: fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", gsaEmail),
+	}
+
+	if gsaEmail != nil {
+		creds.ServiceAccountImpersonationURL = fmt.Sprintf(
+			"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+			*gsaEmail,
+		)
 	}
 
 	return creds

--- a/webhooks/external_account_config_test.go
+++ b/webhooks/external_account_config_test.go
@@ -33,10 +33,34 @@ func TestExternalAccountCredentials_Render(t *testing.T) {
   }
 }`,
 		},
+		{
+			name: "direct-access (no impersonation)",
+			fields: fields{
+				Audience: "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/workload-identity-pool/providers/workload-identity",
+				GSAEmail: "",
+			},
+			want: `{
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/workload-identity-pool/providers/workload-identity",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "file": "/var/run/secrets/sts.googleapis.com/serviceaccount/token",
+    "format": {
+      "type": "text"
+    }
+  }
+}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := NewExternalAccountCredentials(tt.fields.Audience, tt.fields.GSAEmail)
+			var emailArg *string
+			if tt.fields.GSAEmail != "" {
+				e := tt.fields.GSAEmail
+				emailArg = &e
+			}
+			e := NewExternalAccountCredentials(tt.fields.Audience, emailArg)
 			got, err := e.Render(true)
 			if err != nil && !tt.wantErr {
 				t.Errorf("ExternalAccountCredentials.Render() returned unexpected error: %v", err)

--- a/webhooks/identityconfig.go
+++ b/webhooks/identityconfig.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var (
@@ -20,6 +21,8 @@ type GCPWorkloadIdentityConfig struct {
 	ServiceAccountEmail      *string
 	RunAsUser                *int64
 	InjectionMode            InjectionMode
+	TokenExchangeMode        TokenExchangeMode
+	ProjectID                *string
 
 	Audience               *string
 	TokenExpirationSeconds *int64
@@ -31,6 +34,13 @@ const (
 	UndefinedMode InjectionMode = ""
 	GCloudMode    InjectionMode = "gcloud"
 	DirectMode    InjectionMode = "direct"
+)
+
+type TokenExchangeMode string
+
+const (
+	ServiceAccountMode TokenExchangeMode = "service-account"
+	DirectAccessMode   TokenExchangeMode = "direct-access"
 )
 
 func NewGCPWorkloadIdentityConfig(
@@ -49,6 +59,10 @@ func NewGCPWorkloadIdentityConfig(
 
 	if v, ok := sa.Annotations[filepath.Join(annotationDomain, AudienceAnnotation)]; ok {
 		cfg.Audience = &v
+	}
+
+	if v, ok := sa.Annotations[filepath.Join(annotationDomain, ProjectIDAnnotation)]; ok {
+		cfg.ProjectID = &v
 	}
 
 	if v, ok := sa.Annotations[filepath.Join(annotationDomain, TokenExpirationAnnotation)]; ok {
@@ -80,14 +94,45 @@ func NewGCPWorkloadIdentityConfig(
 		cfg.InjectionMode = UndefinedMode
 	}
 
-	if cfg.WorkloadIdentityProvider == nil && cfg.ServiceAccountEmail == nil {
-		return nil, nil
+	if v, ok := sa.Annotations[filepath.Join(annotationDomain, TokenExchangeModeAnnotation)]; ok {
+		switch TokenExchangeMode(strings.ToLower(v)) {
+		case ServiceAccountMode:
+			cfg.TokenExchangeMode = ServiceAccountMode
+		case DirectAccessMode:
+			cfg.TokenExchangeMode = DirectAccessMode
+		default:
+			return nil, fmt.Errorf("%s mode must be '%s', '%s' or unset", filepath.Join(annotationDomain, TokenExchangeModeAnnotation), ServiceAccountMode, DirectAccessMode)
+		}
+	} else {
+		cfg.TokenExchangeMode = ServiceAccountMode
 	}
 
-	if cfg.WorkloadIdentityProvider == nil || cfg.ServiceAccountEmail == nil {
-		return nil, fmt.Errorf("%s, %s must set at a time", filepath.Join(annotationDomain, WorkloadIdentityProviderAnnotation), filepath.Join(annotationDomain, TokenExpirationAnnotation))
+	switch cfg.TokenExchangeMode {
+	case DirectAccessMode:
+		if cfg.WorkloadIdentityProvider == nil {
+			return nil, fmt.Errorf("%s is required when %s is '%s'",
+				filepath.Join(annotationDomain, WorkloadIdentityProviderAnnotation),
+				filepath.Join(annotationDomain, TokenExchangeModeAnnotation),
+				DirectAccessMode,
+			)
+		}
+		if cfg.ServiceAccountEmail != nil {
+			ctrllog.Log.WithName("identityconfig").Info(
+				"ignoring service-account-email annotation in direct-access token-exchange-mode",
+				"serviceaccount", sa.Namespace+"/"+sa.Name,
+			)
+			cfg.ServiceAccountEmail = nil
+		}
+	default: // ServiceAccountMode
+		if cfg.WorkloadIdentityProvider == nil && cfg.ServiceAccountEmail == nil {
+			return nil, nil
+		}
+		if cfg.WorkloadIdentityProvider == nil || cfg.ServiceAccountEmail == nil {
+			return nil, fmt.Errorf("%s, %s must set at a time", filepath.Join(annotationDomain, WorkloadIdentityProviderAnnotation), filepath.Join(annotationDomain, ServiceAccountEmailAnnotation))
+		}
 	}
 
+	// Invariant: WorkloadIdentityProvider is non-nil here — both token-exchange-mode branches above ensure it.
 	if !workloadIdentityProviderRegex.Match([]byte(*cfg.WorkloadIdentityProvider)) {
 		return nil, fmt.Errorf("%s must be form of %s", filepath.Join(annotationDomain, WorkloadIdentityProviderAnnotation), workloadIdentityProviderFmt)
 	}

--- a/webhooks/identityconfig_test.go
+++ b/webhooks/identityconfig_test.go
@@ -46,6 +46,7 @@ var _ = Describe("NewGCPWorkloadIdentityConfig", func() {
 					ServiceAccountEmail:      &saEmail,
 					Audience:                 nil,
 					TokenExpirationSeconds:   nil,
+					TokenExchangeMode:        ServiceAccountMode,
 				}))
 			})
 		})
@@ -68,6 +69,7 @@ var _ = Describe("NewGCPWorkloadIdentityConfig", func() {
 					ServiceAccountEmail:      &saEmail,
 					Audience:                 &audience,
 					TokenExpirationSeconds:   &tokenExpiration,
+					TokenExchangeMode:        ServiceAccountMode,
 				}))
 			})
 		})
@@ -92,6 +94,7 @@ var _ = Describe("NewGCPWorkloadIdentityConfig", func() {
 					Audience:                 &audience,
 					TokenExpirationSeconds:   &tokenExpiration,
 					InjectionMode:            DirectMode,
+					TokenExchangeMode:        ServiceAccountMode,
 				}))
 			})
 		})
@@ -116,6 +119,124 @@ var _ = Describe("NewGCPWorkloadIdentityConfig", func() {
 					Audience:                 &audience,
 					TokenExpirationSeconds:   &tokenExpiration,
 					InjectionMode:            GCloudMode,
+					TokenExchangeMode:        ServiceAccountMode,
+				}))
+			})
+		})
+		When("ServiceAccount with 'direct-access' token-exchange-mode only (no service-account-email)", func() {
+			It("can create GCPWorkloadIdentityConfig", func() {
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation:        workloadProvider,
+							tokenExchangeModeAnnotation: string(DirectAccessMode),
+						},
+					},
+				}
+				idConfig, err := NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idConfig).To(BeEquivalentTo(&GCPWorkloadIdentityConfig{
+					WorkloadIdentityProvider: &workloadProvider,
+					ServiceAccountEmail:      nil,
+					TokenExchangeMode:        DirectAccessMode,
+				}))
+			})
+		})
+		When("ServiceAccount with 'direct-access' mode ignores service-account-email", func() {
+			It("returns config with ServiceAccountEmail cleared", func() {
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation:        workloadProvider,
+							saEmailAnnotation:           saEmail,
+							tokenExchangeModeAnnotation: string(DirectAccessMode),
+						},
+					},
+				}
+				idConfig, err := NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idConfig).To(BeEquivalentTo(&GCPWorkloadIdentityConfig{
+					WorkloadIdentityProvider: &workloadProvider,
+					ServiceAccountEmail:      nil,
+					TokenExchangeMode:        DirectAccessMode,
+				}))
+			})
+		})
+		When("ServiceAccount with explicit 'service-account' token-exchange-mode", func() {
+			It("behaves identically to default", func() {
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation:        workloadProvider,
+							saEmailAnnotation:           saEmail,
+							tokenExchangeModeAnnotation: string(ServiceAccountMode),
+						},
+					},
+				}
+				idConfig, err := NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idConfig).To(BeEquivalentTo(&GCPWorkloadIdentityConfig{
+					WorkloadIdentityProvider: &workloadProvider,
+					ServiceAccountEmail:      &saEmail,
+					TokenExchangeMode:        ServiceAccountMode,
+				}))
+			})
+		})
+		When("ServiceAccount with mixed-case 'DIRECT-ACCESS' token-exchange-mode", func() {
+			It("parses case-insensitively", func() {
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation:        workloadProvider,
+							tokenExchangeModeAnnotation: "DIRECT-ACCESS",
+						},
+					},
+				}
+				idConfig, err := NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idConfig.TokenExchangeMode).To(Equal(DirectAccessMode))
+			})
+		})
+		When("ServiceAccount with project-id annotation in direct-access mode", func() {
+			It("captures the explicit ProjectID", func() {
+				projectID := `my-project`
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation:        workloadProvider,
+							tokenExchangeModeAnnotation: string(DirectAccessMode),
+							projectIDAnnotation:         projectID,
+						},
+					},
+				}
+				idConfig, err := NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idConfig).To(BeEquivalentTo(&GCPWorkloadIdentityConfig{
+					WorkloadIdentityProvider: &workloadProvider,
+					TokenExchangeMode:        DirectAccessMode,
+					ProjectID:                &projectID,
+				}))
+			})
+		})
+		When("ServiceAccount with project-id annotation in service-account mode", func() {
+			It("captures the explicit ProjectID alongside the SA email", func() {
+				projectID := `override-project`
+				sa := corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation: workloadProvider,
+							saEmailAnnotation:    saEmail,
+							projectIDAnnotation:  projectID,
+						},
+					},
+				}
+				idConfig, err := NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(idConfig).To(BeEquivalentTo(&GCPWorkloadIdentityConfig{
+					WorkloadIdentityProvider: &workloadProvider,
+					ServiceAccountEmail:      &saEmail,
+					TokenExchangeMode:        ServiceAccountMode,
+					ProjectID:                &projectID,
 				}))
 			})
 		})
@@ -196,6 +317,36 @@ var _ = Describe("NewGCPWorkloadIdentityConfig", func() {
 				idConfig, err = NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
 				Expect(idConfig).To(BeNil())
 				Expect(err).To(MatchError(ContainSubstring("mode must be")))
+			})
+		})
+		When("ServiceAccount with unparsable token-exchange-mode annotation", func() {
+			It("should raise error", func() {
+				sa = corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							idProviderAnnotation:        workloadProvider,
+							saEmailAnnotation:           saEmail,
+							tokenExchangeModeAnnotation: "not-valid",
+						},
+					},
+				}
+				idConfig, err = NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(idConfig).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring("mode must be")))
+			})
+		})
+		When("ServiceAccount with 'direct-access' mode but no workload-identity-provider", func() {
+			It("should raise error", func() {
+				sa = corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							tokenExchangeModeAnnotation: string(DirectAccessMode),
+						},
+					},
+				}
+				idConfig, err = NewGCPWorkloadIdentityConfig(annotaitonDomain, sa)
+				Expect(idConfig).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring("workload-identity-provider")))
 			})
 		})
 	})

--- a/webhooks/mutatepod.go
+++ b/webhooks/mutatepod.go
@@ -42,12 +42,13 @@ func (m *GCPWorkloadIdentityMutator) mutatePod(pod *corev1.Pod, idConfig GCPWork
 		pod.Annotations = map[string]string{}
 	}
 	pod.Annotations[filepath.Join(m.AnnotationDomain, WorkloadIdentityProviderAnnotation)] = *idConfig.WorkloadIdentityProvider
-	pod.Annotations[filepath.Join(m.AnnotationDomain, ServiceAccountEmailAnnotation)] = *idConfig.ServiceAccountEmail
+	if idConfig.ServiceAccountEmail != nil {
+		pod.Annotations[filepath.Join(m.AnnotationDomain, ServiceAccountEmailAnnotation)] = *idConfig.ServiceAccountEmail
+	}
 	pod.Annotations[filepath.Join(m.AnnotationDomain, AudienceAnnotation)] = audience
 	pod.Annotations[filepath.Join(m.AnnotationDomain, TokenExpirationAnnotation)] = fmt.Sprint(expirationSeconds)
 	if idConfig.InjectionMode == DirectMode {
-		// Add annotation
-		credBody, err := buildExternalCredentialsJson(*idConfig.WorkloadIdentityProvider, *idConfig.ServiceAccountEmail)
+		credBody, err := buildExternalCredentialsJson(*idConfig.WorkloadIdentityProvider, idConfig.ServiceAccountEmail)
 		if err != nil {
 			return err
 		}
@@ -55,12 +56,17 @@ func (m *GCPWorkloadIdentityMutator) mutatePod(pod *corev1.Pod, idConfig GCPWork
 	}
 
 	//
-	// calculate project from service account
+	// resolve project: explicit ProjectID annotation wins; otherwise extract
+	// PROJECT_ID from the service account email. Empty in direct-access mode
+	// when ProjectID annotation is not set.
 	//
-	matches := projectRegex.FindStringSubmatch(*idConfig.ServiceAccountEmail)
 	project := ""
-	if len(matches) >= 2 {
-		project = matches[1] // the group 0 is thw whole match
+	if idConfig.ProjectID != nil {
+		project = *idConfig.ProjectID
+	} else if idConfig.ServiceAccountEmail != nil {
+		if matches := projectRegex.FindStringSubmatch(*idConfig.ServiceAccountEmail); len(matches) >= 2 {
+			project = matches[1]
+		}
 	}
 
 	//
@@ -75,7 +81,7 @@ func (m *GCPWorkloadIdentityMutator) mutatePod(pod *corev1.Pod, idConfig GCPWork
 	//
 	if idConfig.InjectionMode == GCloudMode || idConfig.InjectionMode == UndefinedMode {
 		pod.Spec.InitContainers = prependOrReplaceContainer(pod.Spec.InitContainers, gcloudSetupContainer(
-			*idConfig.WorkloadIdentityProvider, *idConfig.ServiceAccountEmail, project, m.GcloudImage, idConfig.RunAsUser, m.SetupContainerResources,
+			*idConfig.WorkloadIdentityProvider, idConfig.ServiceAccountEmail, project, m.GcloudImage, idConfig.RunAsUser, m.SetupContainerResources,
 		))
 	}
 
@@ -108,7 +114,7 @@ func (m *GCPWorkloadIdentityMutator) mutatePod(pod *corev1.Pod, idConfig GCPWork
 	return nil
 }
 
-func buildExternalCredentialsJson(wiProvider, gsaEmail string) (string, error) {
+func buildExternalCredentialsJson(wiProvider string, gsaEmail *string) (string, error) {
 	aud := fmt.Sprintf("//iam.googleapis.com/%s", wiProvider)
 	creds := NewExternalAccountCredentials(aud, gsaEmail)
 	credJson, err := creds.Render(false)

--- a/webhooks/mutatepod_parts.go
+++ b/webhooks/mutatepod_parts.go
@@ -83,52 +83,63 @@ func (m *GCPWorkloadIdentityMutator) externalCredConfigVolume(defaultMode int32)
 
 // Containers
 func gcloudSetupContainer(
-	workloadIdProvider, saEmail, project, gcloudImage string,
+	workloadIdProvider string,
+	saEmail *string,
+	project, gcloudImage string,
 	runAsUser *int64,
 	resources *corev1.ResourceRequirements,
 ) corev1.Container {
-	// for Restricted Profile in Pod Security Standards
 	securityContext := &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{
-				"ALL",
-			},
+			Drop: []corev1.Capability{"ALL"},
 		},
 	}
-
 	if runAsUser != nil {
 		securityContext.RunAsUser = runAsUser
 	}
 
+	var script string
+	envVars := []corev1.EnvVar{{
+		Name:  "GCP_WORKLOAD_IDENTITY_PROVIDER",
+		Value: workloadIdProvider,
+	}}
+	if saEmail != nil {
+		script = heredoc.Docf(`
+			gcloud iam workload-identity-pools create-cred-config \
+			  $(GCP_WORKLOAD_IDENTITY_PROVIDER) \
+			  --service-account=$(GCP_SERVICE_ACCOUNT) \
+			  --output-file=$(CLOUDSDK_CONFIG)/%s \
+			  --credential-source-file=%s
+			gcloud auth login --cred-file=$(CLOUDSDK_CONFIG)/%s
+		`, ExternalCredConfigFilename,
+			filepath.Join(K8sSATokenMountPath, K8sSATokenName),
+			ExternalCredConfigFilename,
+		)
+		envVars = append(envVars, corev1.EnvVar{Name: "GCP_SERVICE_ACCOUNT", Value: *saEmail})
+	} else {
+		script = heredoc.Docf(`
+			gcloud iam workload-identity-pools create-cred-config \
+			  $(GCP_WORKLOAD_IDENTITY_PROVIDER) \
+			  --output-file=$(CLOUDSDK_CONFIG)/%s \
+			  --credential-source-file=%s
+			gcloud auth login --cred-file=$(CLOUDSDK_CONFIG)/%s
+		`, ExternalCredConfigFilename,
+			filepath.Join(K8sSATokenMountPath, K8sSATokenName),
+			ExternalCredConfigFilename,
+		)
+	}
+	envVars = append(envVars,
+		corev1.EnvVar{Name: "CLOUDSDK_CONFIG", Value: GCloudConfigMountPath},
+		projectEnvVar(project),
+	)
+
 	c := corev1.Container{
-		Name:  GCloudSetupInitContainerName,
-		Image: gcloudImage,
-		Command: []string{
-			"sh", "-c",
-			heredoc.Docf(`
-				gcloud iam workload-identity-pools create-cred-config \
-				  $(GCP_WORKLOAD_IDENTITY_PROVIDER) \
-				  --service-account=$(GCP_SERVICE_ACCOUNT) \
-				  --output-file=$(CLOUDSDK_CONFIG)/%s \
-				  --credential-source-file=%s
-				gcloud auth login --cred-file=$(CLOUDSDK_CONFIG)/%s
-			`, ExternalCredConfigFilename,
-				filepath.Join(K8sSATokenMountPath, K8sSATokenName),
-				ExternalCredConfigFilename,
-			),
-		},
-		VolumeMounts: volumeMountsToAddOrReplace(GCloudMode),
-		Env: []corev1.EnvVar{{
-			Name:  "GCP_WORKLOAD_IDENTITY_PROVIDER",
-			Value: workloadIdProvider,
-		}, {
-			Name:  "GCP_SERVICE_ACCOUNT",
-			Value: saEmail,
-		}, {
-			Name:  "CLOUDSDK_CONFIG",
-			Value: GCloudConfigMountPath,
-		}, projectEnvVar(project)},
+		Name:            GCloudSetupInitContainerName,
+		Image:           gcloudImage,
+		Command:         []string{"sh", "-c", script},
+		VolumeMounts:    volumeMountsToAddOrReplace(GCloudMode),
+		Env:             envVars,
 		SecurityContext: securityContext,
 	}
 	if resources != nil {

--- a/webhooks/mutatepod_parts_test.go
+++ b/webhooks/mutatepod_parts_test.go
@@ -69,8 +69,9 @@ gcloud auth login --cred-file=$(CLOUDSDK_CONFIG)/federation.json
 		},
 	}
 
+	saEmailPtr := saEmail
 	t.Run("Without runAsUser and resources", func(t *testing.T) {
-		actual := gcloudSetupContainer(workloadIdProvider, saEmail, project, gcloudImage, nil, nil)
+		actual := gcloudSetupContainer(workloadIdProvider, &saEmailPtr, project, gcloudImage, nil, nil)
 		expected := *expectedTemplate.DeepCopy()
 		if diff := cmp.Diff(actual, expected); diff != "" {
 			t.Errorf("gcloudSetupContainer() mismatch (-want +got):\n%s", diff)
@@ -79,7 +80,7 @@ gcloud auth login --cred-file=$(CLOUDSDK_CONFIG)/federation.json
 
 	t.Run("With runAsUser", func(t *testing.T) {
 		user := int64(1000)
-		actual := gcloudSetupContainer(workloadIdProvider, saEmail, project, gcloudImage, ptr.To(user), nil)
+		actual := gcloudSetupContainer(workloadIdProvider, &saEmailPtr, project, gcloudImage, ptr.To(user), nil)
 
 		expected := *expectedTemplate.DeepCopy()
 		expected.SecurityContext.RunAsUser = ptr.To(user)
@@ -95,7 +96,7 @@ gcloud auth login --cred-file=$(CLOUDSDK_CONFIG)/federation.json
 				corev1.ResourceCPU: resource.MustParse("100m"),
 			},
 		}
-		actual := gcloudSetupContainer(workloadIdProvider, saEmail, project, gcloudImage, nil, &resources)
+		actual := gcloudSetupContainer(workloadIdProvider, &saEmailPtr, project, gcloudImage, nil, &resources)
 
 		expected := *expectedTemplate.DeepCopy()
 		expected.Resources = resources

--- a/webhooks/mutatepod_test.go
+++ b/webhooks/mutatepod_test.go
@@ -146,7 +146,7 @@ var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 					InitContainers: []corev1.Container{
 						gcloudSetupContainer(
 							*idConfig.WorkloadIdentityProvider,
-							*idConfig.ServiceAccountEmail,
+							idConfig.ServiceAccountEmail,
 							project,
 							m.GcloudImage,
 							idConfig.RunAsUser,
@@ -209,7 +209,7 @@ var _ = Describe("GCPWorkloadIdentityMutator.mutatePod", func() {
 					InitContainers: []corev1.Container{
 						gcloudSetupContainer(
 							*idConfig.WorkloadIdentityProvider,
-							*idConfig.ServiceAccountEmail,
+							idConfig.ServiceAccountEmail,
 							project,
 							m.GcloudImage,
 							idConfig.RunAsUser,

--- a/webhooks/mutator_test.go
+++ b/webhooks/mutator_test.go
@@ -23,6 +23,8 @@ var _ = Describe("GCPWorkloadIdentityMutator", func() {
 
 	var sa corev1.ServiceAccount
 	var saDirect corev1.ServiceAccount
+	var saDirectAccess corev1.ServiceAccount
+	var saDirectAccessGcloud corev1.ServiceAccount
 
 	BeforeEach(func() {
 		sa = corev1.ServiceAccount{
@@ -55,11 +57,43 @@ var _ = Describe("GCPWorkloadIdentityMutator", func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, &saDirect)).NotTo(HaveOccurred())
+		// Direct Access + Direct Injection Service Account (Task 7)
+		saDirectAccess = corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "direct-access-direct",
+				Annotations: map[string]string{
+					idProviderAnnotation:        workloadProvider,
+					audienceAnnotation:          audience,
+					tokenExpirationAnnotation:   fmt.Sprint(tokenExpiration),
+					tokenExchangeModeAnnotation: string(DirectAccessMode),
+					injectionModeAnnotation:     string(DirectMode),
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &saDirectAccess)).NotTo(HaveOccurred())
+		// Direct Access + GCloud Injection Service Account (Task 8) — also exercises project-id annotation
+		saDirectAccessGcloud = corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "direct-access-gcloud",
+				Annotations: map[string]string{
+					idProviderAnnotation:        workloadProvider,
+					audienceAnnotation:          audience,
+					tokenExpirationAnnotation:   fmt.Sprint(tokenExpiration),
+					tokenExchangeModeAnnotation: string(DirectAccessMode),
+					projectIDAnnotation:         project,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &saDirectAccessGcloud)).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		Expect(k8sClient.Delete(ctx, &sa)).NotTo(HaveOccurred())
 		Expect(k8sClient.Delete(ctx, &saDirect)).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, &saDirectAccess)).NotTo(HaveOccurred())
+		Expect(k8sClient.Delete(ctx, &saDirectAccessGcloud)).NotTo(HaveOccurred())
 		Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(namespace)))
 	})
 
@@ -99,7 +133,7 @@ var _ = Describe("GCPWorkloadIdentityMutator", func() {
 					InitContainers: []corev1.Container{
 						decorateDefault(gcloudSetupContainer(
 							workloadProvider,
-							saEmail,
+							&saEmail,
 							project,
 							GcloudImageDefault,
 							&runAsUser,
@@ -230,7 +264,7 @@ var _ = Describe("GCPWorkloadIdentityMutator", func() {
 
 			Expect(k8sClient.Create(ctx, pod)).NotTo(HaveOccurred())
 			m := GCPWorkloadIdentityMutator{AnnotationDomain: AnnotationDomainDefault}
-			externalCreds, _ := buildExternalCredentialsJson(workloadProvider, saEmail)
+			externalCreds, _ := buildExternalCredentialsJson(workloadProvider, &saEmail)
 			expected := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
@@ -258,6 +292,130 @@ var _ = Describe("GCPWorkloadIdentityMutator", func() {
 						Env:          append(envVarsToAddOrReplace(DirectMode), envVarsToAddIfNotPresent(DefaultGCloudRegionDefault, project)...),
 					})},
 					Volumes: m.volumesToAddOrReplace(audience, tokenExpiration, VolumeModeDefault, DirectMode),
+				},
+			}
+
+			Expect(pod.Annotations).To(BeEquivalentTo(expected.Annotations))
+			Expect(pod.Spec.ServiceAccountName).To(BeEquivalentTo(expected.Spec.ServiceAccountName))
+			Expect(pod.Spec.Volumes).To(BeEquivalentTo(expected.Spec.Volumes))
+			Expect(pod.Spec.InitContainers).To(BeEquivalentTo(expected.Spec.InitContainers))
+			Expect(pod.Spec.Containers).To(BeEquivalentTo(expected.Spec.Containers))
+		})
+	})
+	Describe("Direct Access (Direct Injection) Case", func() {
+		It("should inject external cred configurations without service account impersonation via annotation & downwardAPI Volume", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-pod",
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "direct-access-direct",
+					InitContainers: []corev1.Container{{
+						Name:  "ictr",
+						Image: "busybox:test",
+					}},
+					Containers: []corev1.Container{{
+						Name:  "ctr",
+						Image: "busybox:test",
+					}},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, pod)).NotTo(HaveOccurred())
+			m := GCPWorkloadIdentityMutator{AnnotationDomain: AnnotationDomainDefault}
+			externalCreds, _ := buildExternalCredentialsJson(workloadProvider, nil)
+			expected := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						idProviderAnnotation:      workloadProvider,
+						audienceAnnotation:        audience,
+						tokenExpirationAnnotation: fmt.Sprint(tokenExpiration),
+						externalConfigAnnotation:  externalCreds,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "direct-access-direct",
+					InitContainers: []corev1.Container{
+						decorateDefault(corev1.Container{
+							Name:         "ictr",
+							Image:        "busybox:test",
+							VolumeMounts: volumeMountsToAddOrReplace(DirectMode),
+							Env:          append(envVarsToAddOrReplace(DirectMode), envVarsToAddIfNotPresent(DefaultGCloudRegionDefault, "")...),
+						}),
+					},
+					Containers: []corev1.Container{decorateDefault(corev1.Container{
+						Name:         "ctr",
+						Image:        "busybox:test",
+						VolumeMounts: volumeMountsToAddOrReplace(DirectMode),
+						Env:          append(envVarsToAddOrReplace(DirectMode), envVarsToAddIfNotPresent(DefaultGCloudRegionDefault, "")...),
+					})},
+					Volumes: m.volumesToAddOrReplace(audience, tokenExpiration, VolumeModeDefault, DirectMode),
+				},
+			}
+
+			Expect(pod.Annotations).To(BeEquivalentTo(expected.Annotations))
+			Expect(pod.Spec.ServiceAccountName).To(BeEquivalentTo(expected.Spec.ServiceAccountName))
+			Expect(pod.Spec.Volumes).To(BeEquivalentTo(expected.Spec.Volumes))
+			Expect(pod.Spec.InitContainers).To(BeEquivalentTo(expected.Spec.InitContainers))
+			Expect(pod.Spec.Containers).To(BeEquivalentTo(expected.Spec.Containers))
+		})
+	})
+	Describe("Direct Access (GCloud Injection) Case", func() {
+		It("should inject gcloud configurations using project-id annotation, no service account impersonation", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "test-pod",
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "direct-access-gcloud",
+					InitContainers: []corev1.Container{{
+						Name:  "ictr",
+						Image: "busybox:test",
+					}},
+					Containers: []corev1.Container{{
+						Name:  "ctr",
+						Image: "busybox:test",
+					}},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, pod)).NotTo(HaveOccurred())
+			m := GCPWorkloadIdentityMutator{AnnotationDomain: AnnotationDomainDefault}
+			expected := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						idProviderAnnotation:      workloadProvider,
+						audienceAnnotation:        audience,
+						tokenExpirationAnnotation: fmt.Sprint(tokenExpiration),
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "direct-access-gcloud",
+					InitContainers: []corev1.Container{
+						decorateDefault(gcloudSetupContainer(
+							workloadProvider,
+							nil,
+							project,
+							GcloudImageDefault,
+							nil,
+							setupContainerResources,
+						)),
+						decorateDefault(corev1.Container{
+							Name:         "ictr",
+							Image:        "busybox:test",
+							VolumeMounts: volumeMountsToAddOrReplace(GCloudMode),
+							Env:          append(envVarsToAddOrReplace(GCloudMode), envVarsToAddIfNotPresent(DefaultGCloudRegionDefault, project)...),
+						}),
+					},
+					Containers: []corev1.Container{decorateDefault(corev1.Container{
+						Name:         "ctr",
+						Image:        "busybox:test",
+						VolumeMounts: volumeMountsToAddOrReplace(GCloudMode),
+						Env:          append(envVarsToAddOrReplace(GCloudMode), envVarsToAddIfNotPresent(DefaultGCloudRegionDefault, project)...),
+					})},
+					Volumes: m.volumesToAddOrReplace(audience, tokenExpiration, VolumeModeDefault, GCloudMode),
 				},
 			}
 

--- a/webhooks/webhook_suite_test.go
+++ b/webhooks/webhook_suite_test.go
@@ -26,15 +26,17 @@ import (
 )
 
 var (
-	annotaitonDomain          = AnnotationDomainDefault
-	idProviderAnnotation      = filepath.Join(annotaitonDomain, WorkloadIdentityProviderAnnotation)
-	saEmailAnnotation         = filepath.Join(annotaitonDomain, ServiceAccountEmailAnnotation)
-	audienceAnnotation        = filepath.Join(annotaitonDomain, AudienceAnnotation)
-	tokenExpirationAnnotation = filepath.Join(annotaitonDomain, TokenExpirationAnnotation)
-	runAsUserAnnotation       = filepath.Join(annotaitonDomain, RunAsUserAnnotation)
-	injectionModeAnnotation   = filepath.Join(annotaitonDomain, InjectionModeAnnotation)
-	externalConfigAnnotation  = filepath.Join(annotaitonDomain, ExternalCredentialsJsonAnnotation)
-	setupContainerResources   = &corev1.ResourceRequirements{
+	annotaitonDomain            = AnnotationDomainDefault
+	idProviderAnnotation        = filepath.Join(annotaitonDomain, WorkloadIdentityProviderAnnotation)
+	saEmailAnnotation           = filepath.Join(annotaitonDomain, ServiceAccountEmailAnnotation)
+	audienceAnnotation          = filepath.Join(annotaitonDomain, AudienceAnnotation)
+	tokenExpirationAnnotation   = filepath.Join(annotaitonDomain, TokenExpirationAnnotation)
+	runAsUserAnnotation         = filepath.Join(annotaitonDomain, RunAsUserAnnotation)
+	injectionModeAnnotation     = filepath.Join(annotaitonDomain, InjectionModeAnnotation)
+	tokenExchangeModeAnnotation = filepath.Join(annotaitonDomain, TokenExchangeModeAnnotation)
+	projectIDAnnotation         = filepath.Join(annotaitonDomain, ProjectIDAnnotation)
+	externalConfigAnnotation    = filepath.Join(annotaitonDomain, ExternalCredentialsJsonAnnotation)
+	setupContainerResources     = &corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU: resource.MustParse("100m"),
 		},


### PR DESCRIPTION
## Overview

Introduce a new ServiceAccount annotation `cloud.google.com/token-exchange-mode` that selects between two STS token-exchange behaviors:

- `service-account` (default) — preserves the existing behavior. The exchanged token impersonates the GCP service account given by `cloud.google.com/service-account-email`.
- `direct-access` — the workload accesses GCP resources *directly as the federated principal*, with no intermediate GCP service account.

A companion annotation `cloud.google.com/project-id` is also added. Its value is injected into mutated pods as `CLOUDSDK_CORE_PROJECT`.

### ServiceAccount annotation examples

`service-account` mode (default; same as today):

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: app-x
  namespace: service-a
  annotations:
    cloud.google.com/workload-identity-provider: "projects/12345/locations/global/workloadIdentityPools/on-prem-kubernetes/providers/this-cluster"
    cloud.google.com/service-account-email: "app-x@my-project.iam.gserviceaccount.com"
    # cloud.google.com/token-exchange-mode: "service-account"   # optional, this is the default
    # cloud.google.com/project-id: "my-project"                 # optional override; otherwise parsed from the SA email
```

`direct-access` mode:

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: app-x
  namespace: service-a
  annotations:
    cloud.google.com/workload-identity-provider: "projects/12345/locations/global/workloadIdentityPools/on-prem-kubernetes/providers/this-cluster"
    cloud.google.com/token-exchange-mode: "direct-access"
    cloud.google.com/project-id: "my-project"   # required in this mode (the workload-identity-provider only carries a project number)
    # cloud.google.com/service-account-email is not required and is ignored if present
```

## Motivation

GCP Workload Identity Federation supports two consumption models:

1. **Service Account Impersonation** — exchange the federated credential for an STS token, then impersonate a GCP service account and call APIs as that SA.
2. **Direct Resource Access** — bind IAM directly on the federated principal and call APIs as the principal itself, no SA in the middle.

The webhook so far only supported (1). Adding (2) brings several benefits:

- **Removes GCP SA management overhead.** No more creating per-workload SAs and granting `roles/iam.workloadIdentityUser` to wire them up to the federated principal. The path collapses to a single IAM binding directly on the principal.
- **Shorter delegation chain.** The impersonation hop disappears, simplifying audit logs and permission tracing.
- **Avoids SA quota / org-policy friction.** Some organizations heavily restrict service-account creation; direct-access does not need an SA at all.
- **Aligned with Google's recommendation.** Google's own docs [recommend Direct Resource Access for new use cases][impersonation-vs-direct] where supported.

In `direct-access` mode, `service-account-email` is absent, so the project ID can no longer be derived from the SA email. The `workload-identity-provider` path only contains a project *number*, which cannot be used for `CLOUDSDK_CORE_PROJECT`. This forces the introduction of an explicit `cloud.google.com/project-id` annotation.

## Detail Changes

**Generated credentials change shape.** In `direct-access` mode, the `external_account` JSON written for the pod *omits* `service_account_impersonation_url`; the STS token is then used directly against GCP APIs. Concretely the JSON becomes:

```json
{
  "type": "external_account",
  "audience": "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/.../providers/...",
  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
  "token_url": "https://sts.googleapis.com/v1/token",
  "credential_source": {
    "file": "/var/run/secrets/sts.googleapis.com/serviceaccount/token",
    "format": { "type": "text" }
  }
}
```

**Project-ID resolution order.** `cloud.google.com/project-id` annotation → parsed from `service-account-email` → error. The annotation is mandatory in `direct-access` mode (no SA email to fall back to) and acts as an override otherwise.

**Backwards compatibility.** Existing manifests without the new annotation behave identically; the default is `service-account` and every prior code path is preserved.

## Testing

This change has been deployed and validated end-to-end on my own cluster: a workload using `direct-access` mode successfully obtained an STS token from GCP STS and accessed GCP resources directly via a `principal://` IAM binding, with no intermediate service account.

[impersonation-vs-direct]: https://cloud.google.com/iam/docs/workload-identity-federation#impersonation_versus_direct_resource_access
[direct-support]: https://cloud.google.com/iam/docs/federated-identity-supported-services
