### PR TITLE
chore(chart): skip self via webhook-type label and skip annotation

### DIFF
--- a/charts/gcp-workload-identity-federation-webhook/templates/deployment.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/templates/deployment.yaml
@@ -13,7 +13,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
-    webhook-type: gcp-workload-identity-federation-webhook
   {{- include "gcp-workload-identity-federation-webhook.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
@@ -25,6 +24,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        {{ .Values.webhookConfiguration.annotationPrefix }}/skip-pod-identity-webhook: "true"
       {{- include "gcp-workload-identity-federation-webhook.selectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager

--- a/charts/gcp-workload-identity-federation-webhook/templates/deployment.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/templates/deployment.yaml
@@ -13,6 +13,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
+    webhook-type: gcp-workload-identity-federation-webhook
   {{- include "gcp-workload-identity-federation-webhook.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}

--- a/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
@@ -18,12 +18,8 @@ webhooks:
   name: mpod.kb.io
   objectSelector:
     matchExpressions:
-        - key: cloud.google.com/skip-pod-identity-webhook
+        - key: {{ .Values.webhookConfiguration.annotationPrefix }}/skip-pod-identity-webhook
           operator: DoesNotExist
-        - key: webhook-type
-          operator: NotIn
-          values:
-            - gcp-workload-identity-federation-webhook
   rules:
   - apiGroups:
     - ""

--- a/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
@@ -16,6 +16,14 @@ webhooks:
       path: /mutate-v1-pod
   failurePolicy: Ignore
   name: mpod.kb.io
+  objectSelector:
+    matchExpressions:
+        - key: cloud.google.com/skip-pod-identity-webhook
+          operator: DoesNotExist
+        - key: webhook-type
+          operator: NotIn
+          values:
+            - gcp-workload-identity-federation-webhook
   rules:
   - apiGroups:
     - ""

--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -69,3 +69,6 @@ webhookService:
     protocol: TCP
     targetPort: webhook
   type: ClusterIP
+
+webhookConfiguration:
+  annotationPrefix: cloud.google.com


### PR DESCRIPTION
## Overview

Add an `objectSelector` to the chart's `MutatingWebhookConfiguration` and stamp a `webhook-type` label on the controller-manager Deployment. As a result, two classes of pods are excluded from webhook processing:

1. Pods carrying the `cloud.google.com/skip-pod-identity-webhook` label (user opt-out).
2. Pods carrying `webhook-type=gcp-workload-identity-federation-webhook` — that is, **the webhook itself**.

## Motivation

Letting the webhook controller mutate its own pods causes real problems:

- **Bootstrap deadlock.** The webhook pod cannot be admitted while it itself is the admission target — admission requests time out because no webhook pod is yet serving. Recovering a fresh cluster, or redeploying the webhook, becomes flaky.
- **Pointless mutation.** The controller receives its GCP credentials from its own Deployment spec, not via self-mutation. Mutating itself adds no value; it only adds the deadlock risk above.

Operators also commonly want to exempt specific user pods from mutation (e.g. debug pods, pods that mount their own token files). A standardized opt-out label covers that case as well.

## Reference — AWS EKS Pod Identity Webhook

This pattern is borrowed directly from the design used by [aws/amazon-eks-pod-identity-webhook][aws-webhook] (the IRSA mutating webhook).

- AWS defines a `eks.amazonaws.com/skip-pod-identity-webhook` label for the same purpose, and its [`MutatingWebhookConfiguration` `objectSelector`][aws-mwc] only matches pods *without* that label.

[aws-webhook]: https://github.com/aws/amazon-eks-pod-identity-webhook
[aws-mwc]: https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/deploy/mutatingwebhook.yaml
[aws-readme]: https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/README.md
