### PR TITLE
fix: make webhook failurePolicy and reinvocationPolicy configurable

### DIFF
--- a/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
@@ -14,8 +14,8 @@ webhooks:
       name: '{{ include "gcp-workload-identity-federation-webhook.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-v1-pod
-  failurePolicy: {{ .Values.webhook.failurePolicy | default "Ignore" }}
-  reinvocationPolicy: {{ .Values.webhook.reinvocationPolicy | default "Never" }}
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  reinvocationPolicy: {{ .Values.webhook.reinvocationPolicy }}
   name: mpod.kb.io
   rules:
   - apiGroups:

--- a/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/templates/mutating-webhook-configuration.yaml
@@ -14,7 +14,8 @@ webhooks:
       name: '{{ include "gcp-workload-identity-federation-webhook.fullname" . }}-webhook-service'
       namespace: '{{ .Release.Namespace }}'
       path: /mutate-v1-pod
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.webhook.failurePolicy | default "Ignore" }}
+  reinvocationPolicy: {{ .Values.webhook.reinvocationPolicy | default "Never" }}
   name: mpod.kb.io
   rules:
   - apiGroups:

--- a/charts/gcp-workload-identity-federation-webhook/values.yaml
+++ b/charts/gcp-workload-identity-federation-webhook/values.yaml
@@ -62,6 +62,10 @@ metricsService:
     targetPort: metrics
   type: ClusterIP
 
+webhook:
+  failurePolicy: Ignore
+  reinvocationPolicy: Never
+
 webhookService:
   ports:
   - name: webhook


### PR DESCRIPTION
## What

Makes the mutating webhook's `failurePolicy` and `reinvocationPolicy` configurable
via `values.yaml` instead of being hardcoded in the template.

Fixes #137

## Why

`templates/mutating-webhook-configuration.yaml` hardcoded `failurePolicy: Ignore`,
so users had no way to switch it to `Fail` (or tune `reinvocationPolicy`) without
forking the chart. The `webhook` values block did not exist at all.

## Changes

- `templates/mutating-webhook-configuration.yaml`: reference the new values with
  a `default` so the rendered output is unchanged when the values are unset.
- `values.yaml`: add a `webhook` block exposing `failurePolicy` and
  `reinvocationPolicy`, defaulting to the current behaviour.

```diff
 # mutating-webhook-configuration.yaml
-  failurePolicy: Ignore
+  failurePolicy: {{ .Values.webhook.failurePolicy | default "Ignore" }}
+  reinvocationPolicy: {{ .Values.webhook.reinvocationPolicy | default "Never" }}
```

```yaml
# values.yaml
webhook:
  failurePolicy: Ignore
  reinvocationPolicy: Never
```

## Backwards compatibility

Non-breaking. The defaults (`Ignore` / `Never`) match the previous hardcoded
behaviour, so existing installations render identically.

## Testing

`make lint-chart` passes 
Rendered output with defaults (unchanged):